### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/OpenApiGenerator/OpenApiGenerator.csproj
+++ b/src/OpenApiGenerator/OpenApiGenerator.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="microsoft.openapi" Version="1.1.4" />
-    <PackageReference Include="microsoft.openapi.readers" Version="1.0.1" />
+    <PackageReference Include="microsoft.openapi.readers" Version="1.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenApiGenerator/OpenApiGenerator.csproj
+++ b/src/OpenApiGenerator/OpenApiGenerator.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.openapi" Version="1.0.1" />
+    <PackageReference Include="microsoft.openapi" Version="1.1.4" />
     <PackageReference Include="microsoft.openapi.readers" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.OpenApi`, `Microsoft.OpenApi.Readers`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.OpenApi` to `1.1.4` from `1.0.1`
`Microsoft.OpenApi 1.1.4` was published at `2019-09-15T18:33:57Z`, 7 months ago

1 project update:
Updated `src/OpenApiGenerator/OpenApiGenerator.csproj` to `Microsoft.OpenApi` `1.1.4` from `1.0.1`

[Microsoft.OpenApi 1.1.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.OpenApi/1.1.4)

NuKeeper has generated a minor update of `Microsoft.OpenApi.Readers` to `1.1.4` from `1.0.1`
`Microsoft.OpenApi.Readers 1.1.4` was published at `2019-09-15T18:33:58Z`, 7 months ago

1 project update:
Updated `src/OpenApiGenerator/OpenApiGenerator.csproj` to `Microsoft.OpenApi.Readers` `1.1.4` from `1.0.1`

[Microsoft.OpenApi.Readers 1.1.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.OpenApi.Readers/1.1.4)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
